### PR TITLE
Fixed null ptr exception in saveChangeLog().

### DIFF
--- a/src/main/java/hudson/plugins/clearcase/AbstractClearCaseScm.java
+++ b/src/main/java/hudson/plugins/clearcase/AbstractClearCaseScm.java
@@ -552,6 +552,9 @@ public abstract class AbstractClearCaseScm extends SCM {
         @SuppressWarnings("unchecked") Run prevBuild = build.getPreviousBuild();
         Date lastBuildTime = getBuildTime(prevBuild);
         HistoryAction historyAction = createHistoryAction(variableResolver, clearToolLauncher, build);
+        if (historyAction == null) {
+            throw new IOException("Unexpected error when creating historyAction");
+        }
         changelogEntries = historyAction.getChanges(lastBuildTime, getViewPath(variableResolver), coNormalizedViewName, getBranchNames(variableResolver), getViewPaths(variableResolver, build, launcher));
         // Save change log
         if (CollectionUtils.isEmpty(changelogEntries)) {


### PR DESCRIPTION
The function createHistoryAction() may return null in some cases.
Then this leads to null ptr exception in the checkout phase, and thus
the retry mechanism for the checkout is not effective anymore.
Now, this case is caught and an IOException is raised instead of the NPE.
