### PR TITLE
Raise an exception when no baseline is found. 

### DIFF
--- a/src/main/java/hudson/plugins/clearcase/ucm/UcmCommon.java
+++ b/src/main/java/hudson/plugins/clearcase/ucm/UcmCommon.java
@@ -195,6 +195,10 @@ public class UcmCommon {
         } finally {
             rd.close();
         }
+        if (baselines.isEmpty()) {
+            throw new IOException("Unexpected output for command \"cleartool describe -fmt " +
+                                  format + " stream:" + stream + "\" or no available baseline found");
+        }
         List<Baseline> foundationBaselines = new ArrayList<Baseline>();
         BufferedReader br = new BufferedReader(clearTool.describe("%[component]Xp\\n", StringUtils.join(baselines," ")));
         Iterator<String> blIterator = baselines.iterator();


### PR DESCRIPTION
In the case where no baseline is found or when the clearcase command
failed to return correctly, an IOException is raised at the failing point.
Otherwise, the error was reported later when launching another clearcase
command, which was confusing for the user.
