### PR TITLE
Null return create history action

### DIFF
--- a/src/main/java/hudson/plugins/clearcase/AbstractClearCaseScm.java
+++ b/src/main/java/hudson/plugins/clearcase/AbstractClearCaseScm.java
@@ -217,7 +217,7 @@ public abstract class AbstractClearCaseScm extends SCM {
      * @param variableResolver
      * @param useDynamicView
      * @param launcher the command line launcher
-     * @return an action that can poll if there are any changes a ClearCase repository.
+     * @return an action that can poll if there are any changes a ClearCase repository. Never null.
      * @throws InterruptedException 
      * @throws IOException 
      */

--- a/src/main/java/hudson/plugins/clearcase/ClearCaseUcmSCM.java
+++ b/src/main/java/hudson/plugins/clearcase/ClearCaseUcmSCM.java
@@ -205,23 +205,12 @@ public class ClearCaseUcmSCM extends AbstractClearCaseScm {
         UcmHistoryAction action;
         ClearCaseUCMSCMRevisionState oldBaseline = null;
         ClearCaseUCMSCMRevisionState newBaseline = null;
-        PrintStream logger = launcher.getListener().getLogger();
         if (build != null) {
-            try {
-                AbstractBuild<?, ?> previousBuild = (AbstractBuild<?, ?>) build.getPreviousBuild();
-                if (previousBuild != null) {
-                    oldBaseline = build.getPreviousBuild().getAction(ClearCaseUCMSCMRevisionState.class);
-                }
-                newBaseline = (ClearCaseUCMSCMRevisionState) calcRevisionsFromBuild(build, launcher.getLauncher(), launcher.getListener());
-            } catch (IOException e) {
-                Logger.getLogger(ClearCaseUcmSCM.class.getName()).log(Level.SEVERE, "IOException when calculating revisions'", e);
-                e.printStackTrace(logger);
-                return null;
-            } catch (InterruptedException e) {
-                Logger.getLogger(ClearCaseUcmSCM.class.getName()).log(Level.SEVERE, "InterruptedException when calculating revisions'", e);
-                e.printStackTrace(logger);
-                return null;
+            AbstractBuild<?, ?> previousBuild = (AbstractBuild<?, ?>) build.getPreviousBuild();
+            if (previousBuild != null) {
+                oldBaseline = build.getPreviousBuild().getAction(ClearCaseUCMSCMRevisionState.class);
             }
+            newBaseline = (ClearCaseUCMSCMRevisionState) calcRevisionsFromBuild(build, launcher.getLauncher(), launcher.getListener());
         }
         if (isFreezeCode()) {
             action = new FreezeCodeUcmHistoryAction(ct, isUseDynamicView(), configureFilters(variableResolver, build, launcher.getLauncher()), getStream(variableResolver), getViewDrive(), build, oldBaseline, newBaseline);


### PR DESCRIPTION
Modified createHistoryAction in order to throw exceptions instead of returning null if something goes wrong.
This prevents unexpected NPE later in the code.
