### PR TITLE
Changing @ to @@

### DIFF
--- a/src/main/resources/hudson/plugins/clearcase/ClearCaseChangeLogSet/index.jelly
+++ b/src/main/resources/hudson/plugins/clearcase/ClearCaseChangeLogSet/index.jelly
@@ -52,7 +52,7 @@
         			<t:editTypeIcon type="${element.editType}" />
         		</j:if>
         	</td>
-        	<td>${element.file}@${element.version} - ${element.action}</td>
+        	<td>${element.file}@@${element.version} - ${element.action}</td>
         </tr>
       </j:forEach>
     </j:forEach>


### PR DESCRIPTION
When the change log is displayed on the Jenkins UI, the plugin was rendering a single @ character. The typical value of CLEARCASE_XN_SFX variable is with 2 @ signs. Therefore changing @ to @@.
