### PR TITLE
Fixed issue with multiple object selectors introduced with fix on whitesp

### DIFF
--- a/src/main/java/hudson/plugins/clearcase/ClearTool.java
+++ b/src/main/java/hudson/plugins/clearcase/ClearTool.java
@@ -67,6 +67,19 @@ public interface ClearTool {
     Reader describe(String format, String objectSelector) throws IOException, InterruptedException;
 
     /**
+     * Call the cleartool describe with the provided format on the specified object selectors
+     * See http://www.ipnom.com/ClearCase-Commands/describe.html for valid options
+     * 
+     * @param format
+     * @param objectSelectors
+     * @return A reader to the command output
+     * @throws IOException If cleartool throws an error code
+     * @throws InterruptedException If the process is interrupted
+     * @since 1.3
+     */
+    Reader describe(String format, String[] objectSelectors) throws IOException, InterruptedException;
+
+    /**
      * Call diffbl using the two provided baselines (can be stream or baseline)
      * 
      * @param options see http://www.ipnom.com/ClearCase-Commands/diffbl.html

--- a/src/main/java/hudson/plugins/clearcase/ClearToolExec.java
+++ b/src/main/java/hudson/plugins/clearcase/ClearToolExec.java
@@ -95,6 +95,25 @@ public abstract class ClearToolExec implements ClearTool {
     }
 
     @Override
+    public Reader describe(String format, String[] objectSelectors) throws IOException, InterruptedException {
+        Validate.notNull(objectSelectors);
+	Validate.isTrue(objectSelectors.length > 0);
+        ArgumentListBuilder cmd = new ArgumentListBuilder();
+        cmd.add("desc");
+        if (StringUtils.isNotBlank(format)) {
+            cmd.add("-fmt", format);
+        }
+	for (String selector: objectSelectors) {
+	    cmd.add(selector);
+	}
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        launcher.run(cmd.toCommandArray(), null, baos, null);
+        Reader reader = new InputStreamReader(new ByteArrayInputStream(baos.toByteArray()));
+        baos.close();
+        return reader;
+    }
+
+    @Override
     public Reader diffbl(EnumSet<DiffBlOptions> type, String baseline1, String baseline2, String viewPath) throws IOException {
         ArgumentListBuilder cmd = new ArgumentListBuilder();
         cmd.add("diffbl");

--- a/src/main/java/hudson/plugins/clearcase/ucm/UcmCommon.java
+++ b/src/main/java/hudson/plugins/clearcase/ucm/UcmCommon.java
@@ -59,16 +59,16 @@ public class UcmCommon {
             return null;
         }
         List<String> loadRules = new ArrayList<String>();
-        StringBuilder sb = new StringBuilder();
+	List<String> components = new ArrayList<String>();
         for (Baseline bl : baselines) {
             String componentName = bl.getComponentName();
             if (componentName != null) {
-                sb.append("component:").append(componentName).append(" ");
+                components.add("component:" + componentName);
             } else {
                 clearTool.getLauncher().getListener().getLogger().print("[WARNING] " + bl.getBaselineName() + " has a null component\n");
             }
         }
-        Reader reader = clearTool.describe("%[root_dir]p\\n", sb.toString().trim());
+        Reader reader = clearTool.describe("%[root_dir]p\\n", (String[])components.toArray(new String[components.size()]));
         BufferedReader br = new BufferedReader(reader);
         for(String line = br.readLine(); line != null; line = br.readLine()){
             String loadRule = StringUtils.isNotBlank(line) ? line.substring(1) : null;
@@ -200,7 +200,7 @@ public class UcmCommon {
                                   format + " stream:" + stream + "\" or no available baseline found");
         }
         List<Baseline> foundationBaselines = new ArrayList<Baseline>();
-        BufferedReader br = new BufferedReader(clearTool.describe("%[component]Xp\\n", StringUtils.join(baselines," ")));
+        BufferedReader br = new BufferedReader(clearTool.describe("%[component]Xp\\n", (String[])baselines.toArray(new String[baselines.size()])));
         Iterator<String> blIterator = baselines.iterator();
         for(String line = br.readLine(); line != null; line = br.readLine()){
             if (StringUtils.isNotBlank(line)) {

--- a/src/test/java/hudson/plugins/clearcase/ucm/UcmCommonTest.java
+++ b/src/test/java/hudson/plugins/clearcase/ucm/UcmCommonTest.java
@@ -28,7 +28,8 @@ public class UcmCommonTest extends AbstractWorkspaceTest {
 
     @Test
     public void testGenerateLoadRulesFromBaselinesOneBaseline() throws Exception {
-        when(cleartool.describe("%[root_dir]p\\n", "component:comp1@\\pvob")).thenReturn(new StringReader("/vob/comp1"));
+        when(cleartool.describe(eq("%[root_dir]p\\n"), eq(new String[] {"component:comp1@\\pvob"}))).
+	    thenReturn(new StringReader("/vob/comp1"));
         when(cleartool.getLauncher()).thenReturn(launcher);
         when(launcher.getListener()).thenReturn(listener);
         when(listener.getLogger()).thenReturn(System.out);
@@ -38,12 +39,12 @@ public class UcmCommonTest extends AbstractWorkspaceTest {
         String[] loadRules = UcmCommon.generateLoadRulesFromBaselines(cleartool, "mystream", baselines);
         assertTrue(loadRules.length == 1);
         assertEquals("vob/comp1", loadRules[0]);
-        verify(cleartool).describe("%[root_dir]p\\n", "component:comp1@\\pvob");
+        verify(cleartool).describe(eq("%[root_dir]p\\n"), eq(new String[] {"component:comp1@\\pvob"}));
     }
 
     @Test
     public void testGenerateLoadRulesFromBaselinesMultiBaseline() throws Exception {
-        when(cleartool.describe("%[root_dir]p\\n", "component:comp1@\\pvob component:comp2@\\otherpvob")).thenReturn(
+        when(cleartool.describe(eq("%[root_dir]p\\n"), eq(new String[] {"component:comp1@\\pvob", "component:comp2@\\otherpvob"}))).thenReturn(
                 new StringReader("/vob/comp1\n/othervob/comp2"));
         when(cleartool.getLauncher()).thenReturn(launcher);
         when(launcher.getListener()).thenReturn(listener);
@@ -57,6 +58,6 @@ public class UcmCommonTest extends AbstractWorkspaceTest {
         assertTrue(loadRules.length == 2);
         assertEquals("vob/comp1", loadRules[0]);
         assertEquals("othervob/comp2", loadRules[1]);
-        verify(cleartool).describe("%[root_dir]p\\n", "component:comp1@\\pvob component:comp2@\\otherpvob");
+        verify(cleartool).describe(eq("%[root_dir]p\\n"), eq(new String[] {"component:comp1@\\pvob", "component:comp2@\\otherpvob"}));
     }
 }


### PR DESCRIPTION
Fixed issue with multiple object selectors introduced with fix on whitespace handling.

Commit 0b008b84e1 introduced an issue for ct describe on multiple object selectors for baselines and components.

Actually when getting components (resp. root_dirs) for several baselines (resp. components) at once the change in CleartoolExec.describe() method (that do not tokenize anymore the objectSelector string) will pass all baselines (resp. components) in a single argument.
For instance, it generates an arg list such as:
"cleartool" "desc" "-fmt" "%[component]Xp\n" "baseline:baseline_1 baseline:baseline_2"
The error is that in the case of multiple object selectors one must pass "baseline:baseline_1" "baseline:baseline_2" instead.
This fix adds a new overload for the  CleartoolExec.describe() method in the ClearTool interface that accepts a String[] for specifying several object selectors.
