### PR TITLE
[JENKINS-16165] fix for the path to overrideViewStorage.jelly

### DIFF
--- a/src/main/resources/hudson/plugins/clearcase/ClearCaseSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/clearcase/ClearCaseSCM/config.jelly
@@ -117,7 +117,7 @@
       <f:textarea name="cc.excludedRegions" value="${scm.excludedRegions}"
         checkUrl="'${rootURL}/scm/ClearCaseSCM/excludedRegionsCheck?value='+escape(this.value)" />
     </f:entry>
-    <st:include class="${descriptor.clazz}" page="overrideViewStorage.jelly" />
+    <st:include class="${descriptor.clazz}" page="/hudson/plugins/clearcase/AbstractClearcaseScm/overrideViewStorage.jelly" />
     <f:entry title="Additional mkview arguments" help="/plugin/clearcase/mkviewoptionalparam.html">
       <f:expandableTextbox name="cc.mkviewoptionalparam"
         value="${scm.mkviewOptionalParam}" />

--- a/src/main/resources/hudson/plugins/clearcase/ClearCaseUcmSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/clearcase/ClearCaseUcmSCM/config.jelly
@@ -73,7 +73,7 @@
       <f:textarea name="ucm.excludedRegions" value="${scm.excludedRegions}"
         checkUrl="'${rootURL}/scm/ClearCaseSCM/excludedRegionsCheck?value='+escape(this.value)" />
     </f:entry>
-	<st:include class="${descriptor.clazz}" page="overrideViewStorage.jelly" />	
+	<st:include class="${descriptor.clazz}" page="/hudson/plugins/clearcase/AbstractClearcaseScm/overrideViewStorage.jelly" />	
     <f:entry title="Additional mkview arguments" help="/plugin/clearcase/mkviewoptionalparam.html">
       <f:expandableTextbox name="ucm.mkviewoptionalparam"
         value="${scm.mkviewOptionalParam}" />


### PR DESCRIPTION
since this is located now in /hudson/plugins/clearcase/AbstractClearcaseScm
