### PR TITLE
Fixed doesStreamExists throwing Exception even when stream does not exists

### DIFF
--- a/src/main/java/hudson/plugins/clearcase/ClearToolExec.java
+++ b/src/main/java/hudson/plugins/clearcase/ClearToolExec.java
@@ -205,10 +205,10 @@ public abstract class ClearToolExec implements ClearTool {
         }
         catch (IOException e) {
             String cleartoolResult = baos.toString();
-            if (!(cleartoolResult.contains("stream not found"))) {
-                throw e;
+            if (cleartoolResult.contains("stream not found")) {
+                return false;
             }
-            return false;
+            throw e;
         }
         finally {
             baos.close();


### PR DESCRIPTION
Previously proposed fix resolved the issue where doesStreamExists will return true in case the command failed but introduced a regression, causing an Exception to be thrown even when the stream does not exists.

Now the exception thrown by the command will be caught and the command output checked to verify either if the stream does not exists or if another error occured, rethrowing the exception in the second case.
