### PR TITLE
Allow multiple branches to be specified by a single build parameter.

### DIFF
--- a/src/main/java/hudson/plugins/clearcase/ClearCaseSCM.java
+++ b/src/main/java/hudson/plugins/clearcase/ClearCaseSCM.java
@@ -55,7 +55,6 @@ import hudson.util.FormValidation;
 import hudson.util.VariableResolver;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.text.NumberFormat;
@@ -377,10 +376,10 @@ public class ClearCaseSCM extends AbstractClearCaseScm {
     @Override
     public String[] getBranchNames(VariableResolver<String> variableResolver) {
         // split by whitespace, except "\ "
-        String[] branchArray = branch.split("(?<!\\\\)[ \\r\\n]+");
+        String[] branchArray = Util.replaceMacro(branch, variableResolver).split("(?<!\\\\)[ \\r\\n]+");
         // now replace "\ " to " ".
         for (int i = 0; i < branchArray.length; i++) {
-            branchArray[i] = Util.replaceMacro(branchArray[i].replaceAll("\\\\ ", " "), variableResolver);
+            branchArray[i] = branchArray[i].replaceAll("\\\\ ", " ");
         }
         return branchArray;
     }


### PR DESCRIPTION
Currently specifying multiple branches as a single build parameter results in an incorrect lshistory command.

Build parameter: CLEARCASE_BRANCHES='branch1 branch2 branch3'
Plugin branches: ${CLEARCASE_BRANCHES}
Generated lshistory command:
/usr/atria/bin/cleartool lshistory -all -since 21-sep-14.18:07:53utc+0000 -fmt '\"%Nd\" \"%u\" \"%En\" \"%Vn\" \"%e\" \"%o\" \n%c\n' -branch <b>"brtype:branch1 branch2 branch3"</b> -nco vobs/myvob

With the fix, the plugin correctly generates a single lshistory command for each branch:
/usr/atria/bin/cleartool lshistory -all -since 21-sep-14.18:07:53utc+0000 -fmt '\"%Nd\" \"%u\" \"%En\" \"%Vn\" \"%e\" \"%o\" \n%c\n' -branch <b>brtype:branch1</b> -nco vobs/myvob
/usr/atria/bin/cleartool lshistory -all -since 21-sep-14.18:07:53utc+0000 -fmt '\"%Nd\" \"%u\" \"%En\" \"%Vn\" \"%e\" \"%o\" \n%c\n' -branch <b>brtype:branch2</b> -nco vobs/myvob
/usr/atria/bin/cleartool lshistory -all -since 21-sep-14.18:07:53utc+0000 -fmt '\"%Nd\" \"%u\" \"%En\" \"%Vn\" \"%e\" \"%o\" \n%c\n' -branch <b>brtype:branch3</b> -nco vobs/myvob
